### PR TITLE
Added fix for Ubuntu 16.04 being used in Dockerfile.gpu instead of Ub…

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:8.0-cudnn5-devel
+FROM nvidia/cuda:8.0-cudnn5-devel-ubuntu14.04
 
 MAINTAINER Sai Soundararaj <saip@outlook.com>
 


### PR DESCRIPTION
…untu 14.04

Without this change the compilation of the GPU image would fail with 

"E: Unable to locate package libopenjpeg2"

which is likely due to Ubuntu 16.04 unexpectedly being used as the Nvidia base image instead of Ubuntu 14.04. (i.e. using the tag "nvidia/cuda:8.0-cudnn5-devel" instead of "nvidia/cuda:8.0-cudnn5-devel-ubuntu14.04"). 

