### PR TITLE
Including OpenCV in docker image

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -40,6 +40,40 @@ RUN apt-get update && apt-get install -y \
 		vim \
 		wget \
 		zlib1g-dev \
+		qt5-default \
+		libvtk6-dev \
+		zlib1g-dev \
+		libjpeg-dev \
+		libwebp-dev \
+		libpng-dev \
+		libtiff5-dev \
+		libjasper-dev \
+		libopenexr-dev \
+		libgdal-dev \
+		libdc1394-22-dev \
+		libavcodec-dev \
+		libavformat-dev \
+		libswscale-dev \
+		libtheora-dev \
+		libvorbis-dev \
+		libxvidcore-dev \
+		libx264-dev \
+		yasm \
+		libopencore-amrnb-dev \
+		libopencore-amrwb-dev \
+		libv4l-dev \
+		libxine2-dev \
+		libtbb-dev \
+		libeigen3-dev \
+		python-dev \
+		python-tk \
+		python-numpy \
+		python3-dev \
+		python3-tk \
+		python3-numpy \
+		ant \
+		default-jdk \
+		doxygen \
 		&& \
 	apt-get clean && \
 	apt-get autoremove && \
@@ -172,6 +206,17 @@ RUN luarocks install nn && \
 	cd /root && git clone https://github.com/facebook/iTorch.git && \
 	cd iTorch && \
 	luarocks make
+
+# Install OpenCV
+RUN git clone --depth 1 https://github.com/opencv/opencv.git /root/opencv && \
+	cd /root/opencv && \
+	mkdir build && \
+	cd build && \
+	cmake -DWITH_QT=ON -DWITH_OPENGL=ON -DFORCE_VTK=ON -DWITH_TBB=ON -DWITH_GDAL=ON -DWITH_XINE=ON -DBUILD_EXAMPLES=ON .. && \
+	make -j"$(nproc)"  && \
+	make install && \
+	ldconfig && \
+	echo 'ln /dev/null /dev/raw1394' >> ~/.bashrc
 
 
 # Set up notebook config

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -46,6 +46,40 @@ RUN apt-get update && apt-get install -y \
 		vim \
 		wget \
 		zlib1g-dev \
+		qt5-default \
+		libvtk6-dev \
+		zlib1g-dev \
+		libjpeg-dev \
+		libwebp-dev \
+		libpng-dev \
+		libtiff5-dev \
+		libjasper-dev \
+		libopenexr-dev \
+		libgdal-dev \
+		libdc1394-22-dev \
+		libavcodec-dev \
+		libavformat-dev \
+		libswscale-dev \
+		libtheora-dev \
+		libvorbis-dev \
+		libxvidcore-dev \
+		libx264-dev \
+		yasm \
+		libopencore-amrnb-dev \
+		libopencore-amrwb-dev \
+		libv4l-dev \
+		libxine2-dev \
+		libtbb-dev \
+		libeigen3-dev \
+		python-dev \
+		python-tk \
+		python-numpy \
+		python3-dev \
+		python3-tk \
+		python3-numpy \
+		ant \
+		default-jdk \
+		doxygen \
 		&& \
 	apt-get clean && \
 	apt-get autoremove && \
@@ -185,6 +219,16 @@ RUN luarocks install nn && \
 	cd iTorch && \
 	luarocks make
 
+# Install OpenCV
+RUN git clone --depth 1 https://github.com/opencv/opencv.git /root/opencv && \
+	cd /root/opencv && \
+	mkdir build && \
+	cd build && \
+	cmake -DWITH_QT=ON -DWITH_OPENGL=ON -DFORCE_VTK=ON -DWITH_TBB=ON -DWITH_GDAL=ON -DWITH_XINE=ON -DBUILD_EXAMPLES=ON .. && \
+	make -j"$(nproc)"  && \
+	make install && \
+	ldconfig && \
+	echo 'ln /dev/null /dev/raw1394' >> ~/.bashrc
 
 # Set up notebook config
 COPY jupyter_notebook_config.py /root/.jupyter/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This is what you get out of the box when you create a container with the provide
 * [Torch](http://torch.ch/) (includes nn, cutorch, cunn and cuDNN bindings)
 * [iPython/Jupyter Notebook](http://jupyter.org/) (including iTorch kernel)
 * [Numpy](http://www.numpy.org/), [SciPy](https://www.scipy.org/), [Pandas](http://pandas.pydata.org/), [Scikit Learn](http://scikit-learn.org/), [Matplotlib](http://matplotlib.org/)
+& [OpenCV](http://opencv.org/)
 * A few common libraries used for deep learning
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is what you get out of the box when you create a container with the provide
 * [Torch](http://torch.ch/) (includes nn, cutorch, cunn and cuDNN bindings)
 * [iPython/Jupyter Notebook](http://jupyter.org/) (including iTorch kernel)
 * [Numpy](http://www.numpy.org/), [SciPy](https://www.scipy.org/), [Pandas](http://pandas.pydata.org/), [Scikit Learn](http://scikit-learn.org/), [Matplotlib](http://matplotlib.org/)
-& [OpenCV](http://opencv.org/)
+* [OpenCV](http://opencv.org/)
 * A few common libraries used for deep learning
 
 ## Setup


### PR DESCRIPTION
@saiprashanths 

I've added [opencv](http://opencv.org/) to the docker file as well. For most CNN's used with caffe, there is almost always some image manipulation(resizing image, converting to grayscale etc). Though openCV by itself is not a deep learning library, I think it is a good compliment to caffe. 

Please review it and merge if it fits in.

EDIT : Verified and built it to check that it works

Thanks,
Anoop