### PR TITLE
CUDA_CUDA_LIBRARY Not Found Fix

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -224,7 +224,7 @@ RUN git clone --depth 1 https://github.com/opencv/opencv.git /root/opencv && \
 	cd /root/opencv && \
 	mkdir build && \
 	cd build && \
-	cmake -DWITH_QT=ON -DWITH_OPENGL=ON -DFORCE_VTK=ON -DWITH_TBB=ON -DWITH_GDAL=ON -DWITH_XINE=ON -DBUILD_EXAMPLES=ON .. && \
+	cmake -DWITH_QT=ON -DWITH_OPENGL=ON -DCUDA_CUDA_LIBRARY=/usr/local/cuda/lib64/stubs/libcuda.so -DFORCE_VTK=ON -DWITH_TBB=ON -DWITH_GDAL=ON -DWITH_XINE=ON -DBUILD_EXAMPLES=ON .. && \
 	make -j"$(nproc)"  && \
 	make install && \
 	ldconfig && \


### PR DESCRIPTION
Received the follow error when building, this fixes it


-- Configuring incomplete, errors occurred!
See also "/root/opencv/build/CMakeFiles/CMakeOutput.log".
See also "/root/opencv/build/CMakeFiles/CMakeError.log".
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
CUDA_CUDA_LIBRARY (ADVANCED)
    linked by target "example_gpu_alpha_comp" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_bgfg_segm" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_cascadeclassifier" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_cascadeclassifier_nvidia_api" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_driver_api_multi" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_driver_api_stereo_multi" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_farneback_optical_flow" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_generalized_hough" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_hog" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_houghlines" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_morphology" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_multi" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_opengl" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_optical_flow" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_opticalflow_nvidia_api" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_pyrlk_optical_flow" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_stereo_match" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_stereo_multi" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_super_resolution" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_surf_keypoint_matcher" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_video_reader" in directory /root/opencv/samples/gpu
    linked by target "example_gpu_video_writer" in directory /root/opencv/samples/gpu