### PR TITLE
Fix OpenCV build

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -224,7 +224,7 @@ RUN git clone --depth 1 https://github.com/opencv/opencv.git /root/opencv && \
 	cd /root/opencv && \
 	mkdir build && \
 	cd build && \
-	cmake -DWITH_QT=ON -DWITH_OPENGL=ON -DFORCE_VTK=ON -DWITH_TBB=ON -DWITH_GDAL=ON -DWITH_XINE=ON -DBUILD_EXAMPLES=ON .. && \
+	cmake -DWITH_QT=ON -DWITH_OPENGL=ON -DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs/ -DFORCE_VTK=ON -DWITH_TBB=ON -DWITH_GDAL=ON -DWITH_XINE=ON -DBUILD_EXAMPLES=ON .. && \
 	make -j"$(nproc)"  && \
 	make install && \
 	ldconfig && \


### PR DESCRIPTION
This commit adds -DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs to the cmake command line, as recommended by Obeyed in the discussion of pull request #48 .  This fixes the build issue described in that pull request.