### PR TITLE
Fix for Typo + Theano Warning

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -172,7 +172,7 @@ RUN pip --no-cache-dir install git+git://github.com/Theano/Theano.git@${THEANO_V
 	echo "[global]\ndevice=cpu\nfloatX=float32\nmode=FAST_RUN \
 		\n[lib]\ncnmem=0.95 \
 		\n[nvcc]\nfastmath=True \
-		\n[blas]\nldflag = -L/usr/lib/openblas-base -lopenblas \
+		\n[blas]\nldflags = -L/usr/lib/ -lblas \
 		\n[DebugMode]\ncheck_finite=1" \
 	> /root/.theanorc
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -178,7 +178,7 @@ RUN pip --no-cache-dir install git+git://github.com/Theano/Theano.git@${THEANO_V
 	echo "[global]\ndevice=gpu\nfloatX=float32\noptimizer_including=cudnn\nmode=FAST_RUN \
 		\n[lib]\ncnmem=0.95 \
 		\n[nvcc]\nfastmath=True \
-		\n[blas]\nldflag = -L/usr/lib/openblas-base -lopenblas \
+		\n[blas]\nldflags = -L/usr/lib/ -lblas \
 		\n[DebugMode]\ncheck_finite=1" \
 	> /root/.theanorc
 


### PR DESCRIPTION
Two changes:

1) The argument to `.theanorc` is `ldflags` so that was changed as a result.

2) Theano throws a warning:
```
WARNING (theano.tensor.blas): We did not found a dynamic library into the library_dir of the library we use for blas. If you use ATLAS, make sure to compile it with dynamics library.
``` 
This fixes the warning.